### PR TITLE
Fix the compiler include list

### DIFF
--- a/toolchains/compilers/gcc_arm_none_eabi/gcc_arm_none_repository.bzl
+++ b/toolchains/compilers/gcc_arm_none_eabi/gcc_arm_none_repository.bzl
@@ -49,14 +49,16 @@ def _com_gcc_arm_none_repository_impl(repository_ctx):
         os,
     ))
     include_paths = include_tools.ProccessResponse(response.stderr)
-    include_flags = ["-isystem" + path for path in include_paths]
+    include_flags = []
+    for include_path in include_paths:
+        include_flags += ["-isystem", include_path]
     include_bazel_template_input = include_tools.CommandLineToTemplateString(include_flags)
     include_paths_template_input = include_tools.CommandLineToTemplateString(include_paths)
     repository_ctx.file(
         "defs.bzl",
         """
 SYSTEM_INCLUDE_COMMAND_LINE = {}
-SYSTEM_INCLUDE_PATHS= {}
+SYSTEM_INCLUDE_PATHS = {}
 """.format(include_bazel_template_input, include_paths_template_input),
     )
 

--- a/toolchains/compilers/llvm/llvm_repository.bzl
+++ b/toolchains/compilers/llvm/llvm_repository.bzl
@@ -35,14 +35,16 @@ def _llvm_repository_impl(repository_ctx):
     include_paths.append(
         _get_resource_directory(repository_ctx),
     )
-    include_flags = ["-isystem" + path for path in include_paths]
+    include_flags = []
+    for include_path in include_paths:
+        include_flags += ["-isystem", include_path]
     include_bazel_template_input = include_tools.CommandLineToTemplateString(include_flags)
     include_paths_template_input = include_tools.CommandLineToTemplateString(include_paths)
     repository_ctx.file(
         "defs.bzl",
         """
 SYSTEM_INCLUDE_COMMAND_LINE = {}
-SYSTEM_INCLUDE_PATHS= {}
+SYSTEM_INCLUDE_PATHS = {}
 SYSTEM_SYSROOT = "{}"
 """.format(include_bazel_template_input, include_paths_template_input, sysroot_path),
     )

--- a/toolchains/tools/include_tools/include_tools.bzl
+++ b/toolchains/tools/include_tools/include_tools.bzl
@@ -28,6 +28,8 @@ def ProccessResponse(shell_command_result):
     for line in lines:
         if "#include <...> search starts here:" == line:
             start_of_includes_found = True
+        if "End of search list." == line:
+            break
         line = line.replace(" ", "")
         if start_of_includes_found and (line.startswith("/") or line.startswith("c:\\")):
             line = line.replace("\\","/")


### PR DESCRIPTION
On my machine (ubuntu 20.04), the include directory list of the compiler is wrongly generated by the rule.

- the `-isystem` flag is concatenated before the paths
- There is a corrupted path with `-D__USES_INITFINI__` and some other strange things in the middle
- The paths are duplicated

**external/com_gcc_arm_none_eabi_compiler/defs.bzl before the PR:**
```python
SYSTEM_INCLUDE_COMMAND_LINE = [
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/newlib-nano",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/9.2.1",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/9.2.1/arm-none-eabi",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/9.2.1/backward",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/lib/gcc/arm-none-eabi/9.2.1/include",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/lib/gcc/arm-none-eabi/9.2.1/include-fixed",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/arm-none-eabi-D__USES_INITFINI__/dev/null-mcpu=arm7tdmi-mfloat-abi=soft-marm-march=armv4t",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/newlib-nano",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/9.2.1",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/9.2.1/arm-none-eabi",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/9.2.1/backward",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/lib/gcc/arm-none-eabi/9.2.1/include",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/lib/gcc/arm-none-eabi/9.2.1/include-fixed",
    "-isystemexternal/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include",
]
SYSTEM_INCLUDE_PATHS = [
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/newlib-nano",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/9.2.1",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/9.2.1/arm-none-eabi",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/9.2.1/backward",
    "external/com_gcc_arm_none_eabi_compiler/lib/gcc/arm-none-eabi/9.2.1/include",
    "external/com_gcc_arm_none_eabi_compiler/lib/gcc/arm-none-eabi/9.2.1/include-fixed",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi-D__USES_INITFINI__/dev/null-mcpu=arm7tdmi-mfloat-abi=soft-marm-march=armv4t",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/newlib-nano",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/9.2.1",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/9.2.1/arm-none-eabi",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/9.2.1/backward",
    "external/com_gcc_arm_none_eabi_compiler/lib/gcc/arm-none-eabi/9.2.1/include",
    "external/com_gcc_arm_none_eabi_compiler/lib/gcc/arm-none-eabi/9.2.1/include-fixed",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include",
]
```
When I run the following command in the terminal the output is not duplicated
```bash
$ bin/arm-none-eabi-cpp -E -x c++ -specs=nano.specs -specs=nosys.specs - -v /dev/null
Using built-in specs.
Reading specs from /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/lib/nano.specs
rename spec link to nano_link
rename spec link_gcc_c_sequence to nano_link_gcc_c_sequence
rename spec cpp_unique_options to nano_cpp_unique_options
Reading specs from /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/lib/nosys.specs
rename spec link_gcc_c_sequence to nosys_link_gcc_c_sequence
COLLECT_GCC=bin/arm-none-eabi-cpp
Target: arm-none-eabi
Configured with: /mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/src/gcc/configure --target=arm-none-eabi --prefix=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native --libexecdir=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native/lib --infodir=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native/share/doc/gcc-arm-none-eabi/info --mandir=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native/share/doc/gcc-arm-none-eabi/man --htmldir=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native/share/doc/gcc-arm-none-eabi/html --pdfdir=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native/share/doc/gcc-arm-none-eabi/pdf --enable-languages=c,c++ --enable-plugins --disable-decimal-float --disable-libffi --disable-libgomp --disable-libmudflap --disable-libquadmath --disable-libssp --disable-libstdcxx-pch --disable-nls --disable-shared --disable-threads --disable-tls --with-gnu-as --with-gnu-ld --with-newlib --with-headers=yes --with-python-dir=share/gcc-arm-none-eabi --with-sysroot=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native/arm-none-eabi --build=x86_64-linux-gnu --host=x86_64-linux-gnu --with-gmp=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/build-native/host-libs/usr --with-mpfr=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/build-native/host-libs/usr --with-mpc=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/build-native/host-libs/usr --with-isl=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/build-native/host-libs/usr --with-libelf=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/build-native/host-libs/usr --with-host-libstdcxx='-static-libgcc -Wl,-Bstatic,-lstdc++,-Bdynamic -lm' --with-pkgversion='GNU Tools for Arm Embedded Processors 9-2019-q4-major' --with-multilib-list=rmprofile
Thread model: single
gcc version 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 
COLLECT_GCC_OPTIONS='-E' '-specs=nano.specs' '-specs=nosys.specs' '-v' '-mcpu=arm7tdmi' '-mfloat-abi=soft' '-marm' '-march=armv4t'
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/cc1plus -E -isystem =/include/newlib-nano -quiet -v -iprefix /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/ -isysroot /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../arm-none-eabi -D__USES_INITFINI__ - -mcpu=arm7tdmi -mfloat-abi=soft -marm -march=armv4t
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1/arm-none-eabi"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1/backward"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/include"
ignoring nonexistent directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../arm-none-eabi/usr/local/include"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/include-fixed"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include"
ignoring nonexistent directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../arm-none-eabi/usr/include"
#include "..." search starts here:
#include <...> search starts here:
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../arm-none-eabi/include/newlib-nano
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1/arm-none-eabi
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1/backward
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/include
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/include-fixed
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include
End of search list.
```
But I printed the output of the same command executed by bazel and I got this output
```bash
Using built-in specs.
Reading specs from /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/lib/nano.specs
rename spec link to nano_link
rename spec link_gcc_c_sequence to nano_link_gcc_c_sequence
rename spec cpp_unique_options to nano_cpp_unique_options
Reading specs from /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/lib/nosys.specs
rename spec link_gcc_c_sequence to nosys_link_gcc_c_sequence
COLLECT_GCC=bin/arm-none-eabi-cpp
Target: arm-none-eabi
Configured with: /mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/src/gcc/configure --target=arm-none-eabi --prefix=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native --libexecdir=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native/lib --infodir=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native/share/doc/gcc-arm-none-eabi/info --mandir=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native/share/doc/gcc-arm-none-eabi/man --htmldir=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native/share/doc/gcc-arm-none-eabi/html --pdfdir=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native/share/doc/gcc-arm-none-eabi/pdf --enable-languages=c,c++ --enable-plugins --disable-decimal-float --disable-libffi --disable-libgomp --disable-libmudflap --disable-libquadmath --disable-libssp --disable-libstdcxx-pch --disable-nls --disable-shared --disable-threads --disable-tls --with-gnu-as --with-gnu-ld --with-newlib --with-headers=yes --with-python-dir=share/gcc-arm-none-eabi --with-sysroot=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/install-native/arm-none-eabi --build=x86_64-linux-gnu --host=x86_64-linux-gnu --with-gmp=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/build-native/host-libs/usr --with-mpfr=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/build-native/host-libs/usr --with-mpc=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/build-native/host-libs/usr --with-isl=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/build-native/host-libs/usr --with-libelf=/mnt/workspace/workspace/GCC-9-pipeline/jenkins-GCC-9-pipeline-100_20191030_1572397542/build-native/host-libs/usr --with-host-libstdcxx='-static-libgcc -Wl,-Bstatic,-lstdc++,-Bdynamic -lm' --with-pkgversion='GNU Tools for Arm Embedded Processors 9-2019-q4-major' --with-multilib-list=rmprofile
Thread model: single
gcc version 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 
COLLECT_GCC_OPTIONS='-E' '-specs=nano.specs' '-specs=nosys.specs' '-v' '-mcpu=arm7tdmi' '-mfloat-abi=soft' '-marm' '-march=armv4t'
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/cc1plus -E -isystem =/include/newlib-nano -quiet -v -iprefix /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/ -isysroot /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../arm-none-eabi -D__USES_INITFINI__ - -mcpu=arm7tdmi -mfloat-abi=soft -marm -march=armv4t
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1/arm-none-eabi"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1/backward"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/include"
ignoring nonexistent directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../arm-none-eabi/usr/local/include"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/include-fixed"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include"
ignoring nonexistent directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../arm-none-eabi/usr/include"
#include "..." search starts here:
#include <...> search starts here:
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../arm-none-eabi/include/newlib-nano
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1/arm-none-eabi
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1/backward
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/include
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/include-fixed
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include
End of search list.
COLLECT_GCC_OPTIONS='-E' '-specs=nano.specs' '-specs=nosys.specs' '-v' '-mcpu=arm7tdmi' '-mfloat-abi=soft' '-marm' '-march=armv4t'
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/cc1plus -E -isystem =/include/newlib-nano -quiet -v -iprefix /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/ -isysroot /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../arm-none-eabi -D__USES_INITFINI__ /dev/null -mcpu=arm7tdmi -mfloat-abi=soft -marm -march=armv4t
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1/arm-none-eabi"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1/backward"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/include"
ignoring nonexistent directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../arm-none-eabi/usr/local/include"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/include-fixed"
ignoring duplicate directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/../../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include"
ignoring nonexistent directory "/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../arm-none-eabi/usr/include"
#include "..." search starts here:
#include <...> search starts here:
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../arm-none-eabi/include/newlib-nano
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1/arm-none-eabi
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include/c++/9.2.1/backward
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/include
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/include-fixed
 /home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include
End of search list.
COMPILER_PATH=/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/:/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/:/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/
LIBRARY_PATH=/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/:/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/:/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/lib/:/home/kin/.cache/bazel/_bazel_kin/7035caef2827ff512b8f6ddb59d19323/external/com_gcc_arm_none_eabi_compiler/bin/../arm-none-eabi/lib/
COLLECT_GCC_OPTIONS='-E' '-specs=nano.specs' '-specs=nosys.specs' '-v' '-mcpu=arm7tdmi' '-mfloat-abi=soft' '-marm' '-march=armv4t'
```
We can see that the second part of the output is printed twice. I don't know why but as a workaround I removed every lines after the `End of search list.` to discard the duplication.

I also put the `-isystem` in a separate element in the list.

I also edited the clangd toolchain and tried to test my changes but I don't know how to configure it. I tried and failed.

**external/com_gcc_arm_none_eabi_compiler/defs.bzl after the PR:**
```python
SYSTEM_INCLUDE_COMMAND_LINE = [
    "-isystem",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/newlib-nano",
    "-isystem",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/11.3.1",
    "-isystem",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/11.3.1/arm-none-eabi",
    "-isystem",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/11.3.1/backward",
    "-isystem",
    "external/com_gcc_arm_none_eabi_compiler/lib/gcc/arm-none-eabi/11.3.1/include",
    "-isystem",
    "external/com_gcc_arm_none_eabi_compiler/lib/gcc/arm-none-eabi/11.3.1/include-fixed",
    "-isystem",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include",
]
SYSTEM_INCLUDE_PATHS = [
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/newlib-nano",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/11.3.1",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/11.3.1/arm-none-eabi",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include/c++/11.3.1/backward",
    "external/com_gcc_arm_none_eabi_compiler/lib/gcc/arm-none-eabi/11.3.1/include",
    "external/com_gcc_arm_none_eabi_compiler/lib/gcc/arm-none-eabi/11.3.1/include-fixed",
    "external/com_gcc_arm_none_eabi_compiler/arm-none-eabi/include",
]
```

