### PR TITLE
Fixes command line length too long for Windows

### DIFF
--- a/toolchains/gcc_arm_none_eabi/gcc_arm_none_toolchain.bzl
+++ b/toolchains/gcc_arm_none_eabi/gcc_arm_none_toolchain.bzl
@@ -306,7 +306,7 @@ def gcc_arm_none_toolchain(name, compiler_components, architecture, float_abi, e
         strip_files = compiler_components,
         as_files = compiler_components,
         ar_files = compiler_components,
-        supports_param_files = 0,
+        supports_param_files = 1,
         toolchain_config = ":" + toolchain_config,
         toolchain_identifier = "arm-none-eabi",
     )


### PR DESCRIPTION
This commit adds support for param files. This is important for Windows since even the most basic STM32Cube project ends up with more lines than Windows supports.