### PR TITLE
Add support for generate_linkmap

### DIFF
--- a/toolchains/clang/clang_toolchain.bzl
+++ b/toolchains/clang/clang_toolchain.bzl
@@ -156,6 +156,7 @@ def _clang_toolchain_config_info_impl(ctx):
             common_features.output_format,
             common_features.coverage,
             common_features.misc,
+            common_features.generate_linkmap,
         ],
     )
     return toolchain_config_info

--- a/toolchains/features/common/impl/clang.bzl
+++ b/toolchains/features/common/impl/clang.bzl
@@ -273,6 +273,24 @@ _OPT_FEATURE = feature(
     provides = ["compilation_mode"],
 )
 
+_GENERATE_LINKMAP_FEATURE = feature(
+    name = "generate_linkmap",
+    enabled = True,
+    flag_sets = [
+        flag_set(
+            actions = _LD_ALL_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-Wl,-Map=%{output_execpath}.map", # if is_linux else "-Wl,-map,%{output_execpath}.map",
+                    ],
+                    expand_if_available = "output_execpath",
+                ),
+            ],
+        ),
+    ],
+)
+
 # Leaving for compatibility
 _OUTPUT_FORMAT_FEATURE = feature(
     name = "output_format",
@@ -333,4 +351,5 @@ def GetClangCommonFeatures(include_paths, sysroot = "", architecture = "native",
         output_format = _OUTPUT_FORMAT_FEATURE,
         coverage = _COVERAGE_FEATURE,
         misc = _MISC,
+        generate_linkmap = _GENERATE_LINKMAP_FEATURE,
     )

--- a/toolchains/features/common/impl/gcc.bzl
+++ b/toolchains/features/common/impl/gcc.bzl
@@ -276,6 +276,24 @@ _OUTPUT_FORMAT_FEATURE = feature(
     ],
 )
 
+_GENERATE_LINKMAP_FEATURE = feature(
+    name = "generate_linkmap",
+    enabled = True,
+    flag_sets = [
+        flag_set(
+            actions = _LD_ALL_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-Wl,-Map=%{output_execpath}.map", # if is_linux else "-Wl,-map,%{output_execpath}.map",
+                    ],
+                    expand_if_available = "output_execpath",
+                ),
+            ],
+        ),
+    ],
+)
+
 _MISC_FEATURE = feature(
     name = "misc",
     enabled = True,
@@ -313,4 +331,5 @@ def GetGccCommonFeatures(include_paths, sysroot = "", architecture = "native", f
         output_format = _OUTPUT_FORMAT_FEATURE,
         misc = _MISC_FEATURE,
         coverage = _COVERAGE_FEATURE,
+        generate_linkmap = _GENERATE_LINKMAP_FEATURE,
     )

--- a/toolchains/features/common/types.bzl
+++ b/toolchains/features/common/types.bzl
@@ -22,6 +22,7 @@ CC_ALL_COMMON_FEATURES_INFO = {
     "fastbuild": "Compile quickly, for fast development",
     "output_format": "The output format of the compilers *.stripped target, (default binary)",
     "coverage": "A set of features that don't fit in any other categories",
+    "generate_linkmap": "Generates a mapfile during the link stage",
     "misc": "A set of features that don't fit in any other categories",
     "type_name": "The type name for this provider",
 }
@@ -40,6 +41,7 @@ def all_common_features(
         fastbuild,
         output_format,
         coverage,
+        generate_linkmap,
         misc):
     """ all_common_features represents the minimal set of features that should be implemented for a portable toolchain
 
@@ -55,6 +57,7 @@ def all_common_features(
         fastbuild: Configure the fastbuild mode, to speed up developement
         output_format: The output format for the {target}.stripped target (default binary)
         coverage: Feature for instrumenting code coverage
+        generate_linkmap: Generates a mapfile during the link stage
         misc: The set of features that don't fit anywhere else
 
     Returns:
@@ -71,6 +74,7 @@ def all_common_features(
         fastbuild,
         output_format,
         coverage,
+        generate_linkmap,
         misc,
     ]
     for arg in args:
@@ -91,6 +95,7 @@ def all_common_features(
         fastbuild = fastbuild,
         output_format = output_format,
         coverage = coverage,
+        generate_linkmap = generate_linkmap,
         misc = misc,
         type_name = "cc_all_common_feature_info",
     )

--- a/toolchains/features/embedded/impl/gcc.bzl
+++ b/toolchains/features/embedded/impl/gcc.bzl
@@ -92,6 +92,7 @@ _SYS_SPEC_FEATURE = feature(
                         "-lc",
                         "-lstdc++",
                         "-lnosys",
+                        "-specs=nano.specs",
                     ],
                 ),
             ],
@@ -134,6 +135,24 @@ _CC_CONSTRUCTOR_DESTRUCTOR_FEATURE = feature(
     ],
 )
 
+_GENERATE_LINKMAP_FEATURE = feature(
+    name = "generate_linkmap",
+    enabled = True,
+    flag_sets = [
+        flag_set(
+            actions = _LD_ALL_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-Wl,-Map=%{output_execpath}.map", # if is_linux else "-Wl,-map,%{output_execpath}.map",
+                    ],
+                    expand_if_available = "output_execpath",
+                ),
+            ],
+        ),
+    ],
+)
+
 def GetGccEmbeddedFeatures():
     """ GetGccEmbeddedFeatures returns features relevant to embedded developement
     """
@@ -142,4 +161,5 @@ def GetGccEmbeddedFeatures():
         runtime_type_information = _RUNTIME_TYPE_INFORMATION_FEATURE,
         sys_spec = _SYS_SPEC_FEATURE,
         cc_constructor_destructor = _CC_CONSTRUCTOR_DESTRUCTOR_FEATURE,
+        generate_linkmap = _GENERATE_LINKMAP_FEATURE,
     )

--- a/toolchains/features/embedded/impl/gcc.bzl
+++ b/toolchains/features/embedded/impl/gcc.bzl
@@ -135,24 +135,6 @@ _CC_CONSTRUCTOR_DESTRUCTOR_FEATURE = feature(
     ],
 )
 
-_GENERATE_LINKMAP_FEATURE = feature(
-    name = "generate_linkmap",
-    enabled = True,
-    flag_sets = [
-        flag_set(
-            actions = _LD_ALL_ACTIONS,
-            flag_groups = [
-                flag_group(
-                    flags = [
-                        "-Wl,-Map=%{output_execpath}.map", # if is_linux else "-Wl,-map,%{output_execpath}.map",
-                    ],
-                    expand_if_available = "output_execpath",
-                ),
-            ],
-        ),
-    ],
-)
-
 def GetGccEmbeddedFeatures():
     """ GetGccEmbeddedFeatures returns features relevant to embedded developement
     """
@@ -161,5 +143,4 @@ def GetGccEmbeddedFeatures():
         runtime_type_information = _RUNTIME_TYPE_INFORMATION_FEATURE,
         sys_spec = _SYS_SPEC_FEATURE,
         cc_constructor_destructor = _CC_CONSTRUCTOR_DESTRUCTOR_FEATURE,
-        generate_linkmap = _GENERATE_LINKMAP_FEATURE,
     )

--- a/toolchains/features/embedded/type.bzl
+++ b/toolchains/features/embedded/type.bzl
@@ -11,6 +11,7 @@ CC_ALL_EMBEDDED_FEATURES_INFO = {
     "sys_spec": "Configuration for the system spec (Must default to no system spec)",
     "cc_constructor_destructor": "Must disable destructors on global c++ variables, and allow instantiation of global variables only once",
     "type_name": "The type name for this provider",
+    "generate_linkmap": "Generates a mapfile during the link stage",
 }
 CcAllEmbeddedFeatureInfo = provider(fields = CC_ALL_EMBEDDED_FEATURES_INFO)
 
@@ -18,7 +19,8 @@ def all_embedded_features(
         exceptions,
         runtime_type_information,
         sys_spec,
-        cc_constructor_destructor):
+        cc_constructor_destructor,
+        generate_linkmap):
     """ all_common_features represents the minimal set of features that should be implemented for a portable toolchain
 
     Args:
@@ -26,6 +28,7 @@ def all_embedded_features(
         runtime_type_information: Compile with run time type information (disable by default)
         sys_spec: Define the system spec for this target (Must default ot no system spec)
         cc_constructor_destructor: Must disable destructors on global c++ variables, and allow instantiation of global variables only once (Should be enabled by default)
+        generate_linkmap: Generates a mapfile during the link stage
 
     Returns:
         CCAllEmbeddedFeatureInfo: All the common embedded features required to make a minimal toolchain
@@ -35,6 +38,7 @@ def all_embedded_features(
         runtime_type_information,
         sys_spec,
         cc_constructor_destructor,
+        generate_linkmap,
     ]
     for arg in args:
         if not _is_feature(arg):
@@ -47,4 +51,5 @@ def all_embedded_features(
         runtime_type_information = runtime_type_information,
         sys_spec = sys_spec,
         cc_constructor_destructor = cc_constructor_destructor,
+        generate_linkmap = generate_linkmap,
     )

--- a/toolchains/features/embedded/type.bzl
+++ b/toolchains/features/embedded/type.bzl
@@ -11,7 +11,6 @@ CC_ALL_EMBEDDED_FEATURES_INFO = {
     "sys_spec": "Configuration for the system spec (Must default to no system spec)",
     "cc_constructor_destructor": "Must disable destructors on global c++ variables, and allow instantiation of global variables only once",
     "type_name": "The type name for this provider",
-    "generate_linkmap": "Generates a mapfile during the link stage",
 }
 CcAllEmbeddedFeatureInfo = provider(fields = CC_ALL_EMBEDDED_FEATURES_INFO)
 
@@ -19,8 +18,7 @@ def all_embedded_features(
         exceptions,
         runtime_type_information,
         sys_spec,
-        cc_constructor_destructor,
-        generate_linkmap):
+        cc_constructor_destructor):
     """ all_common_features represents the minimal set of features that should be implemented for a portable toolchain
 
     Args:
@@ -28,7 +26,6 @@ def all_embedded_features(
         runtime_type_information: Compile with run time type information (disable by default)
         sys_spec: Define the system spec for this target (Must default ot no system spec)
         cc_constructor_destructor: Must disable destructors on global c++ variables, and allow instantiation of global variables only once (Should be enabled by default)
-        generate_linkmap: Generates a mapfile during the link stage
 
     Returns:
         CCAllEmbeddedFeatureInfo: All the common embedded features required to make a minimal toolchain
@@ -38,7 +35,6 @@ def all_embedded_features(
         runtime_type_information,
         sys_spec,
         cc_constructor_destructor,
-        generate_linkmap,
     ]
     for arg in args:
         if not _is_feature(arg):
@@ -51,5 +47,4 @@ def all_embedded_features(
         runtime_type_information = runtime_type_information,
         sys_spec = sys_spec,
         cc_constructor_destructor = cc_constructor_destructor,
-        generate_linkmap = generate_linkmap,
     )

--- a/toolchains/gcc_arm_none_eabi/gcc_arm_none_toolchain.bzl
+++ b/toolchains/gcc_arm_none_eabi/gcc_arm_none_toolchain.bzl
@@ -158,11 +158,11 @@ def _gcc_arm_none_toolchain_config_info_impl(ctx):
             common_features.opt,
             common_features.fastbuild,
             common_features.output_format,
+            common_features.generate_linkmap,
             embedded_features.exceptions,
             embedded_features.runtime_type_information,
             embedded_features.sys_spec,
             embedded_features.cc_constructor_destructor,
-            embedded_features.generate_linkmap,
         ],
     )
     return toolchain_config_info

--- a/toolchains/gcc_arm_none_eabi/gcc_arm_none_toolchain.bzl
+++ b/toolchains/gcc_arm_none_eabi/gcc_arm_none_toolchain.bzl
@@ -162,6 +162,7 @@ def _gcc_arm_none_toolchain_config_info_impl(ctx):
             embedded_features.runtime_type_information,
             embedded_features.sys_spec,
             embedded_features.cc_constructor_destructor,
+            embedded_features.generate_linkmap,
         ],
     )
     return toolchain_config_info


### PR DESCRIPTION
Add support for generate_linkmap feature for gcc.

Also add `-specs=nano.specs` to link flags when it's included in compile flags so expected and actual specs line up.